### PR TITLE
force all packages to rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"private": true,
 	"scripts": {
 		"clean": "del packages/*/node_modules packages/*/dist node_modules",
-		"build": "npx turbo run build",
+		"build": "npx turbo run build --force",
 		"format": "prettier --write \"**/*.{js,jsx,mjs,ts,tsx,json,css,scss,md,sol}\""
 	},
 	"devDependencies": {


### PR DESCRIPTION
Adding a force parameter because if you delete the "dist" folder manually and rebuild the project, the dist file will not be created again unless the log file is deleted or a change is made in the repo. so adding the extra parameter would make absolutely sure a fresh build is created with every run of the command.