### PR TITLE
implement browser build script for client

### DIFF
--- a/packages/client/.babel.browser.config.js
+++ b/packages/client/.babel.browser.config.js
@@ -1,0 +1,40 @@
+module.exports = {
+	presets: [
+		[
+			'@babel/preset-env',
+			{
+				modules: false,
+				useBuiltIns: 'usage',
+				corejs: 3,
+				bugfixes: true,
+				shippedProposals: true,
+				targets: {
+					browsers: [
+						'supports async-functions',
+						'supports cryptography',
+						'supports es6',
+						'supports promises',
+						'supports promise-finally',
+						'supports es6-generators',
+						'supports rtcpeerconnection',
+						'not dead',
+						'not ie <= 11',
+						'not ie_mob <= 11',
+					],
+				},
+				exclude: [
+					'transform-regenerator',
+					'@babel/plugin-transform-regenerator',
+				],
+			},
+		],
+		['@babel/preset-typescript'],
+	],
+	plugins: [
+		'transform-typescript-metadata',
+		['@babel/plugin-proposal-decorators', { legacy: true }],
+		'lodash',
+		'add-module-exports',
+		'@babel/plugin-transform-modules-commonjs',
+	],
+};

--- a/packages/client/browser.html
+++ b/packages/client/browser.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <p>A webpage to import the client code and use it</p>
+    <code>const ls = new window.Logstore.LogStoreClient()</code>
+</body>
+<script src="./dist/browser/streamr-client.web.js"></script>
+</html>

--- a/packages/client/browser.html
+++ b/packages/client/browser.html
@@ -9,6 +9,11 @@
 <body>
     <p>A webpage to import the client code and use it</p>
     <code>const ls = new window.Logstore.LogStoreClient()</code>
+    <code>>> ls</code>
 </body>
-<script src="./dist/browser/streamr-client.web.js"></script>
+<script src="./dist/browser/streamr-client.web.js">
+</script>
+<script>
+    const ls = new window.Logstore.LogStoreClient()
+</script>
 </html>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"format": "prettier --write .",
 		"postbuild": "bash copy-package.sh",
-		"build": "npm run clean; NODE_ENV=production npm run build:node-production && npm run build:browser-production",
+		"build": "npm run clean; npm run build:node-production && npm run build:browser-production",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"clean": "jest --clearCache || true; rm -rf dist  *.tsbuildinfo node_modules/.cache || true",
 		"build:browser-development": "NODE_ENV=development webpack --mode=development --progress",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,10 +9,15 @@
 	"types": "./dist/types/src/exports.d.ts",
 	"main": "./dist/src/exports.js",
 	"scripts": {
-		"postbuild": "bash copy-package.sh",
-		"build": "tsc",
 		"format": "prettier --write .",
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"postbuild": "bash copy-package.sh",
+		"build": "npm run clean; NODE_ENV=production npm run build:node-production && npm run build:browser-production",
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"clean": "jest --clearCache || true; rm -rf dist  *.tsbuildinfo node_modules/.cache || true",
+		"build:browser-development": "NODE_ENV=development webpack --mode=development --progress",
+		"build:browser-production": "NODE_ENV=production webpack --mode=production --progress",
+		"build:node-development": "NODE_ENV=development tsc",
+		"build:node-production": "NODE_ENV=production tsc"
 	},
 	"dependencies": {
 		"@concertodao/logstore-contracts": "workspace:^",
@@ -53,7 +58,9 @@
 		"strict-event-emitter-types": "^2.0.0",
 		"ts-toolbelt": "^9.6.0",
 		"tsyringe": "^4.7.0",
-		"uuid": "^9.0.0"
+		"uuid": "^9.0.0",
+		"@babel/runtime": "^7.16.3",
+		"@babel/runtime-corejs3": "^7.16.3"
 	},
 	"devDependencies": {
 		"@streamr/test-utils": "^8.0.2",
@@ -75,6 +82,25 @@
 		"jest-mock-extended": "^3.0.4",
 		"ts-essentials": "^9.3.0",
 		"ts-jest": "^29.0.5",
-		"typescript": "^4.9.5"
+		"typescript": "^4.9.5",
+		"git-revision-webpack-plugin": "^5.0.0",
+		"lodash-webpack-plugin": "^0.11.6",
+		"node-polyfill-webpack-plugin": "^1.1.4",
+		"terser-webpack-plugin": "^5.2.5",
+		"webpack": "^5.64.1",
+		"webpack-bundle-analyzer": "^4.5.0",
+		"webpack-cli": "^4.9.1",
+		"webpack-merge": "^5.8.0",
+		"@babel/core": "^7.16.0",
+		"@babel/plugin-proposal-decorators": "^7.16.4",
+		"@babel/plugin-transform-modules-commonjs": "^7.16.0",
+		"@babel/plugin-transform-runtime": "^7.16.4",
+		"@babel/preset-env": "^7.16.4",
+		"@babel/preset-typescript": "^7.16.0",
+		"babel-loader": "^9.1.2",
+		"babel-plugin-add-module-exports": "^1.0.4",
+		"babel-plugin-lodash": "^3.3.4",
+		"babel-plugin-transform-typescript-metadata": "^0.3.2",
+		"ts-loader": "^9.3.1"
 	}
 }

--- a/packages/client/src/LogStoreClient.ts
+++ b/packages/client/src/LogStoreClient.ts
@@ -43,7 +43,7 @@ export class LogStoreClient extends StreamrClient {
 		delete streamrClientConfig.contracts?.logStoreNodeManagerChainAddress;
 		delete streamrClientConfig.contracts?.logStoreStoreManagerChainAddress;
 		delete streamrClientConfig.contracts?.logStoreTheGraphUrl;
-		super(streamrClientConfig, container);
+		super(streamrClientConfig);
 
 		const strictConfig = createStrictConfig(config);
 		const authentication = createAuthentication(strictConfig);

--- a/packages/client/src/shim/node-fetch.ts
+++ b/packages/client/src/shim/node-fetch.ts
@@ -1,0 +1,9 @@
+type FetchResponse = Response;
+// In browsers, the node-fetch package is replaced with this to use native fetch
+export default ((typeof window !== 'undefined' &&
+	typeof window.fetch !== 'undefined' &&
+	window.fetch.bind(window)) ||
+	(typeof fetch !== 'undefined' && fetch) ||
+	undefined)!;
+
+export { FetchResponse as Response };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -3,4 +3,12 @@
  */
 import { F } from 'ts-toolbelt';
 
+import { LogStoreClient } from './LogStoreClient';
+
 export type MaybeAsync<T extends F.Function> = T | F.Promisify<T>; // Utility Type: make a function maybe async
+
+declare global {
+	interface Window {
+		LogStoreClient: LogStoreClient;
+	}
+}

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -19,7 +19,6 @@ const gitRevisionPlugin = new GitRevisionPlugin()
 
 module.exports = (_, argv) => {
     const isProduction = argv.mode === 'production' || process.env.NODE_ENV === 'production'
-
     const analyze = !!process.env.BUNDLE_ANALYSIS
 
     const commonConfig = {
@@ -122,9 +121,8 @@ module.exports = (_, argv) => {
             ] : [])
         ]
     })
-
+    
     let clientMinifiedConfig
-
     if (isProduction) {
         clientMinifiedConfig = merge({}, clientConfig, {
             cache: false,
@@ -147,5 +145,6 @@ module.exports = (_, argv) => {
             },
         })
     }
+
     return [clientConfig, clientMinifiedConfig].filter(Boolean)
 }

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -1,0 +1,151 @@
+/* eslint-disable prefer-template */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'development' // set a default NODE_ENV
+
+const path = require('path')
+
+const webpack = require('webpack')
+const TerserPlugin = require('terser-webpack-plugin')
+const LodashWebpackPlugin = require('lodash-webpack-plugin')
+const { merge } = require('webpack-merge')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
+
+const pkg = require('./package.json')
+
+const gitRevisionPlugin = new GitRevisionPlugin()
+
+
+module.exports = (_, argv) => {
+    const isProduction = argv.mode === 'production' || process.env.NODE_ENV === 'production'
+
+    const analyze = !!process.env.BUNDLE_ANALYSIS
+
+    const commonConfig = {
+        cache: {
+            type: 'filesystem',
+        },
+        name: 'streamr-client',
+        mode: isProduction ? 'production' : 'development',
+        entry: {
+            'streamr-client': path.join(__dirname, 'src', 'LogStoreClient.ts'),
+        },
+        devtool: 'source-map',
+        output: {
+            umdNamedDefine: true,
+        },
+        optimization: {
+            minimize: false,
+            moduleIds: 'named',
+        },
+        module: {
+            rules: [
+                {
+                    test: /(\.jsx|\.js|\.ts)$/,
+                    exclude: /(node_modules|bower_components)/,
+                    use: {
+                        loader: 'babel-loader',
+                        options: {
+                            configFile: path.resolve(__dirname, '.babel.browser.config.js'),
+                            babelrc: false,
+                            cacheDirectory: true,
+                        }
+                    }
+                }
+            ]
+        },
+        resolve: {
+            modules: ['node_modules', ...require.resolve.paths(''), path.resolve('./vendor')],
+            extensions: ['.json', '.js', '.ts'],
+        },
+        plugins: [
+            gitRevisionPlugin,
+            new webpack.EnvironmentPlugin({
+                NODE_ENV: process.env.NODE_ENV,
+                version: pkg.version,
+                GIT_VERSION: gitRevisionPlugin.version(),
+                GIT_COMMITHASH: gitRevisionPlugin.commithash(),
+                GIT_BRANCH: gitRevisionPlugin.branch(),
+            })
+        ],
+        performance: {
+            hints: 'warning',
+        },
+    }
+
+    const clientConfig = merge({}, commonConfig, {
+        target: 'web',
+        output: {
+            filename: 'browser/[name].web.js',
+            libraryTarget: 'umd',
+            library: 'Logstore',
+            globalObject: 'globalThis',
+        },
+        resolve: {
+            alias: {
+                stream: 'readable-stream',
+                util: 'util',
+                http: path.resolve('./src/shim/http-https.ts'),
+                '@ethersproject/wordlists': require.resolve('@ethersproject/wordlists/lib/browser-wordlists.js'),
+                https: path.resolve('./src/shim/http-https.ts'),
+                crypto: require.resolve('crypto-browserify'),
+                buffer: require.resolve('buffer/'),
+                'node-fetch': path.resolve('./src/shim/node-fetch.ts'),
+                // swap out ServerPersistence for BrowserPersistence becase of node fs dependencies
+                [path.resolve('./src/utils/persistence/ServerPersistence.ts')]: (
+                    path.resolve('./src/utils/persistence/BrowserPersistence.ts')
+                ),
+            },
+            fallback: {
+                module: false,
+                fs: false,
+                net: false,
+                http: false,
+                https: false,
+                express: false,
+                ws: false,
+                '@web3modal/standalone': false
+            }
+        },
+        plugins: [
+            new NodePolyfillPlugin({
+                excludeAliases: ['console'],
+            }),
+            new LodashWebpackPlugin(),
+            ...(analyze ? [
+                new BundleAnalyzerPlugin({
+                    analyzerMode: 'static',
+                    openAnalyzer: false,
+                    generateStatsFile: true,
+                })
+            ] : [])
+        ]
+    })
+
+    let clientMinifiedConfig
+
+    if (isProduction) {
+        clientMinifiedConfig = merge({}, clientConfig, {
+            cache: false,
+            optimization: {
+                minimize: true,
+                minimizer: [
+                    new TerserPlugin({
+                        parallel: true,
+                        terserOptions: {
+                            ecma: 2018,
+                            output: {
+                                comments: false,
+                            },
+                        },
+                    }),
+                ],
+            },
+            output: {
+                filename: 'browser/[name].web.min.js',
+            },
+        })
+    }
+    return [clientConfig, clientMinifiedConfig].filter(Boolean)
+}


### PR DESCRIPTION
To Test:
- Build the repo
- open the packages/client/browser.html
- open the browser console
- type in `ls` to get an instance of the logstore client