### PR TITLE
Call validateDataAvailability in backoff strategy. Ensure startKey is…

### DIFF
--- a/packages/validator/src/runtime.ts
+++ b/packages/validator/src/runtime.ts
@@ -71,7 +71,7 @@ export default class Runtime implements IRuntimeExtended {
 	// * Data items are produced here for the bundle in local cache. The local bundle is then used for voting on proposed bundles, and creating new bundle proposals?
 	async getDataItem(core: Validator, key: string): Promise<DataItem> {
 		// -------- Validate Data Listener Start Time --------
-		// ? Only if the Pool has started already created Bundles, check to ensure that the listener.startTime > keyOfFirstItem
+		// ? Only if the Pool has started already created Bundles, check to ensure that the listener.startTime < keyOfFirstItem
 		// eslint-disable-next-line
 		if (core.pool.data!.current_key) {
 			const keyOfFirstItem = await this.nextKey(
@@ -82,14 +82,14 @@ export default class Runtime implements IRuntimeExtended {
 			// Is this the first item of the bundle?
 			if (keyOfFirstItem === key) {
 				const keyMs = parseInt(keyOfFirstItem, 10) * 1000;
-				const valid = this.listener.startTime > keyMs;
+				const valid = this.listener.startTime < keyMs;
 				// ? Prevent the Validator Node from passing validateDataAvailability, if keyAfterCurrentKey > listener.startTime
 				if (!valid) {
 					core.logger.warn(
 						`System Listener has started after the start of the Current Bundle Proposal...`
 					);
 					core.logger.debug(
-						`Listener.startTime (${this.listener.startTime}) < keyOfFirstItem (${keyMs})`
+						`Listener.startTime (${this.listener.startTime}) > keyOfFirstItem (${keyMs})`
 					);
 					core.logger.info(
 						`Keep the Validator running until next Bundle starts to participate in the Pool!`

--- a/packages/validator/src/runtime.ts
+++ b/packages/validator/src/runtime.ts
@@ -89,7 +89,7 @@ export default class Runtime implements IRuntimeExtended {
 						`Listener.startTime (${this.listener.startTime}) > keyOfFirstItem (${keyMs})`
 					);
 					core.logger.info(
-						`Keep the Validator running until next Bundle starts to participate in the Pool!`
+						`Keep the Validator running until next Bundle Proposal starts to participate in the Pool!`
 					);
 					return null;
 				}

--- a/packages/validator/src/runtime.ts
+++ b/packages/validator/src/runtime.ts
@@ -68,7 +68,7 @@ export default class Runtime implements IRuntimeExtended {
 		};
 	}
 
-	// ? Producing data items here is include automatic management of local bundles, and proposed bundles.
+	// * Data items are produced here for the bundle in local cache. The local bundle is then used for voting on proposed bundles, and creating new bundle proposals?
 	async getDataItem(core: Validator, key: string): Promise<DataItem> {
 		const keyInt = parseInt(key, 10);
 		if (!keyInt) {
@@ -84,6 +84,7 @@ export default class Runtime implements IRuntimeExtended {
 				// eslint-disable-next-line
 				core.pool.data!.current_key
 			);
+			// Is this the first item of the bundle?
 			if (keyOfFirstItem === key) {
 				const keyMs = parseInt(keyOfFirstItem, 10) * 1000;
 				const valid = this.listener.startTime > keyMs;

--- a/packages/validator/src/runtime.ts
+++ b/packages/validator/src/runtime.ts
@@ -80,7 +80,7 @@ export default class Runtime implements IRuntimeExtended {
 			if (keyOfFirstItem === key) {
 				const keyMs = parseInt(keyOfFirstItem, 10) * 1000;
 				const valid = this.listener.startTime < keyMs;
-				// ? Prevent the Validator Node from passing validateDataAvailability, if keyAfterCurrentKey > listener.startTime
+				// ? Prevent the Validator Node from passing validateDataAvailability, if listener.startTime > keyOfFirstItem
 				if (!valid) {
 					core.logger.warn(
 						`System Listener has started after the start of the Current Bundle Proposal...`

--- a/packages/validator/src/runtime.ts
+++ b/packages/validator/src/runtime.ts
@@ -73,12 +73,9 @@ export default class Runtime implements IRuntimeExtended {
 		// -------- Validate Data Listener Start Time --------
 		// ? Only if the Pool has started already created Bundles, check to ensure that the listener.startTime < keyOfFirstItem
 		// eslint-disable-next-line
-		if (core.pool.data!.current_key) {
-			const keyOfFirstItem = await this.nextKey(
-				core,
-				// eslint-disable-next-line
-				core.pool.data!.current_key
-			);
+		const currentKey = core.pool.data!.current_key;
+		if (currentKey) {
+			const keyOfFirstItem = await this.nextKey(core, currentKey);
 			// Is this the first item of the bundle?
 			if (keyOfFirstItem === key) {
 				const keyMs = parseInt(keyOfFirstItem, 10) * 1000;

--- a/packages/validator/src/threads/SystemListener.ts
+++ b/packages/validator/src/threads/SystemListener.ts
@@ -132,6 +132,7 @@ export class SystemListener {
 	}
 
 	private async onMessage(
+		// eslint-disable-line
 		content: any,
 		metadata: MessageMetadata
 	): Promise<void> {

--- a/packages/validator/src/threads/SystemListener.ts
+++ b/packages/validator/src/threads/SystemListener.ts
@@ -132,7 +132,7 @@ export class SystemListener {
 	}
 
 	private async onMessage(
-		// eslint-disable-line
+		// eslint-disable-next-line
 		content: any,
 		metadata: MessageMetadata
 	): Promise<void> {

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -23,7 +23,7 @@ export async function validateDataAvailability(this: Validator): Promise<void> {
 		{ limitTimeoutMs: 5 * 60 * 1000, increaseByMs: 10 * 1000 },
 		async (err: any, ctx) => {
 			this.logger.info(
-				`Requesting validateDataAvailability was unsuccessful. Retrying in ${(
+				`validateDataAvailability was unsuccessful. Retrying in ${(
 					ctx.nextTimeoutInMs / 1000
 				).toFixed(2)}s ...`
 			);

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,17 +1,35 @@
-import { Validator as KyveValidator } from '@kyvejs/protocol';
+import {
+	callWithBackoffStrategy,
+	Validator as KyveValidator,
+	standardizeJSON,
+} from '@kyvejs/protocol';
 import { validateDataAvailability as runKyveValidateDataAvailability } from '@kyvejs/protocol/dist/src/methods';
 
 import { IRuntimeExtended } from './types';
 
 // Hook into this method
 export async function validateDataAvailability(this: Validator): Promise<void> {
+	this.logger.debug('Home Directory:', this.home);
 	if (this.runtime.setupThreads) {
 		// * We cannot `await setupThreads` here because we need it to run async alongside other threads (ie. Kyve's `runCache` and `runNode`)
 		this.runtime.setupThreads(this, this.home);
 	}
 
-	await runKyveValidateDataAvailability.call(this);
-	this.logger.debug('Home Directory:', this.home);
+	// ? Here we call the validateDataAvailability in a backoff strategy so that it's retried over time -- AFTER the Listener and Time Cache have started
+	await callWithBackoffStrategy(
+		async () => {
+			await runKyveValidateDataAvailability.call(this);
+		},
+		{ limitTimeoutMs: 5 * 60 * 1000, increaseByMs: 10 * 1000 },
+		async (err: any, ctx) => {
+			this.logger.info(
+				`Requesting validateDataAvailability was unsuccessful. Retrying in ${(
+					ctx.nextTimeoutInMs / 1000
+				).toFixed(2)}s ...`
+			);
+			this.logger.debug(standardizeJSON(err));
+		}
+	);
 }
 export default class Validator extends KyveValidator {
 	protected runtime!: IRuntimeExtended;

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -28,6 +28,9 @@ export async function validateDataAvailability(this: Validator): Promise<void> {
 				).toFixed(2)}s ...`
 			);
 			this.logger.debug(standardizeJSON(err));
+
+			this.logger.info('Re-synchronizing Pool State...');
+			await this.syncPoolState(true);
 		}
 	);
 }


### PR DESCRIPTION
… used during validateDataAvailability - even if current_key doesnt exist. Return null which will cause prevalidateDataItem to error during validateDataAvail if current bundle key is > than listener start time