### PR TITLE
Add functionality to fetch messages by Message IDs

### DIFF
--- a/packages/broker/src/helpers/isPresent.ts
+++ b/packages/broker/src/helpers/isPresent.ts
@@ -1,0 +1,3 @@
+export const isPresent = <T>(value: T | undefined): value is T => {
+	return value !== undefined;
+};


### PR DESCRIPTION
Notes:
- `QueryDebugInfo` now accepts stringified message ids to help debug in these cases
- Added both modes, a method to fetch array of `MessageIDs` and another to fetch single (that reuses the array one)
- For cassandra DB, opted to use `cassandraClient.execute` instead of:
	- `cassandraClient.stream` would create multiple streams to fetch one message each
	- `cassandraClient.batch` it doesn't support select, only update/inserts
- Transformed the promises back to a stream to preserve the signature consistency and compatibility
- Passed directly `MessageID` to internal `fetchByMessageID`
- for now we decided to skip not found messages, instead of emitting errors