### PR TITLE
Feature / Feature flag validator dependencies on broker nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 	"scripts": {
 		"modules": "git submodule init && git submodule update",
 		"clean": "del packages/*/node_modules packages/*/dist node_modules",
-		"build": "npx turbo run build --force",
+		"build": "npx turbo run build --force --filter=!./packages/validator",
+		"build:experimental": "npx turbo run build --force",
 		"format": "prettier --write \"**/*.{js,jsx,mjs,ts,tsx,json,css,scss,md,sol}\""
 	},
 	"devDependencies": {

--- a/packages/broker/src/plugins/logStore/LogStorePlugin.ts
+++ b/packages/broker/src/plugins/logStore/LogStorePlugin.ts
@@ -45,6 +45,9 @@ export interface LogStorePluginConfig {
 		clusterSize: number;
 		myIndexInCluster: number;
 	};
+	experimental?: {
+		enableReportDigest?: boolean;
+	};
 }
 
 export class LogStorePlugin extends Plugin<LogStorePluginConfig> {
@@ -173,9 +176,11 @@ export class LogStorePlugin extends Plugin<LogStorePluginConfig> {
 		await this.systemRecovery.start();
 		await this.propagationResolver.start();
 
-		const abortController = new AbortController();
-		// start the report polling process
-		this.reportPoller.start(abortController.signal);
+		if (this.pluginConfig.experimental?.enableReportDigest) {
+			// start the report polling process
+			const abortController = new AbortController();
+			this.reportPoller.start(abortController.signal);
+		}
 
 		const metricsContext = (
 			await this.logStoreClient!.getNode()

--- a/packages/broker/src/plugins/logStore/http/DataQueryFormat.ts
+++ b/packages/broker/src/plugins/logStore/http/DataQueryFormat.ts
@@ -41,23 +41,22 @@ const createPlainTextFormat = (
 	};
 };
 
-export const toObject = (msg: StreamMessage<any>): any => {
+export const toObject = (msg: StreamMessage<any>) => {
 	return {
-		streamId: msg.getStreamId(),
-		streamPartition: msg.getStreamPartition(),
-		timestamp: msg.getTimestamp(),
-		sequenceNumber: msg.getSequenceNumber(),
-		publisherId: msg.getPublisherId(),
-		msgChainId: msg.getMsgChainId(),
-		messageType: msg.messageType,
-		contentType: msg.contentType,
-		encryptionType: msg.encryptionType,
-		groupKeyId: msg.groupKeyId,
+		metadata: {
+			id: msg.getMessageID(),
+			prevMsgRef: msg.getPreviousMessageRef(),
+			messageType: msg.messageType,
+			contentType: msg.contentType,
+			encryptionType: msg.encryptionType,
+			groupKeyId: msg.groupKeyId,
+			newGroupKey: msg.getNewGroupKey(),
+			signature: msg.signature,
+		},
 		content:
 			msg.encryptionType === EncryptionType.NONE
 				? msg.getParsedContent()
 				: msg.getSerializedContent(),
-		signature: msg.signature,
 	};
 };
 

--- a/packages/client/src/LogStoreClient.ts
+++ b/packages/client/src/LogStoreClient.ts
@@ -1,6 +1,5 @@
 import type {
 	MessageListener,
-	MessageStream,
 	Stream,
 	StreamDefinition,
 } from '@logsn/streamr-client';
@@ -18,6 +17,7 @@ import {
 } from './Config';
 import { LogStoreClientEventEmitter, LogStoreClientEvents } from './events';
 import { LogStoreClientConfig } from './LogStoreClientConfig';
+import { LogStoreMessageStream } from './LogStoreMessageStream';
 import { HttpApiQueryDict, Queries, QueryOptions, QueryType } from './Queries';
 import { LogStoreRegistry } from './registry/LogStoreRegistry';
 import { QueryManager } from './registry/QueryManager';
@@ -103,7 +103,7 @@ export class LogStoreClient extends StreamrClient {
 		streamDefinition: StreamDefinition,
 		options: QueryOptions,
 		onMessage?: MessageListener
-	): Promise<MessageStream> {
+	): Promise<LogStoreMessageStream> {
 		const streamPartId = await this.streamIdBuilder.toStreamPartID(
 			streamDefinition
 		);

--- a/packages/client/src/LogStoreMessageStream.ts
+++ b/packages/client/src/LogStoreMessageStream.ts
@@ -1,0 +1,72 @@
+/**
+ * Wrapper around PushPipeline specific to StreamMessages.
+ * Subscriptions are MessageStreams.
+ * Not all MessageStreams are Subscriptions.
+ */
+import { MessageListener, MessageStream } from '@logsn/streamr-client';
+import {
+	EncryptedGroupKey,
+	MessageID,
+	MessageRef,
+	StreamMessage,
+} from '@streamr/protocol';
+
+export type LogStoreMessageMetadata = {
+	id: MessageID;
+	prevMsgRef: MessageRef | null;
+	messageType: number;
+	contentType: number;
+	encryptionType: number;
+	groupKeyId: string | null;
+	newGroupKey: EncryptedGroupKey | null;
+	signature: string;
+};
+
+export type LogStoreMessage = {
+	content: unknown;
+	metadata: LogStoreMessageMetadata;
+};
+
+/**
+ * Provides asynchronous iteration with
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of | for await .. of}.
+ */
+export class LogStoreMessageStream implements AsyncIterable<LogStoreMessage> {
+	constructor(public messageStream: MessageStream) {}
+
+	/**
+	 * Attach a legacy onMessage handler and consume if necessary.
+	 * onMessage is passed parsed content as first arument, and streamMessage as second argument.
+	 */
+	useLegacyOnMessageHandler(onMessage: MessageListener): this {
+		this.messageStream.useLegacyOnMessageHandler(onMessage);
+		return this;
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<LogStoreMessage> {
+		for await (const msg of this.messageStream) {
+			// @ts-expect-error this is marked as internal in MessageStream
+			const streamMessage: StreamMessage = msg.streamMessage;
+			yield convertStreamMessageToMessage(streamMessage);
+		}
+	}
+}
+
+export const convertStreamMessageToMessage = (
+	msg: StreamMessage
+): LogStoreMessage => {
+	return {
+		content: msg.getParsedContent(),
+		metadata: {
+			id: msg.getMessageID(),
+			prevMsgRef: msg.getPreviousMessageRef(),
+			newGroupKey: msg.getNewGroupKey(),
+			signature: msg.signature,
+			// I'm also including these for further usage:
+			messageType: msg.messageType,
+			contentType: msg.contentType,
+			encryptionType: msg.encryptionType,
+			groupKeyId: msg.groupKeyId,
+		},
+	};
+};

--- a/packages/client/test/e2e/query.test.ts
+++ b/packages/client/test/e2e/query.test.ts
@@ -5,7 +5,7 @@ import {
 	prepareStakeForQueryManager,
 	prepareStakeForStoreManager,
 } from '@logsn/shared';
-import { Message, Stream, StreamPermission } from '@logsn/streamr-client';
+import { Stream, StreamPermission } from '@logsn/streamr-client';
 import type { ErrorSignal } from '@logsn/streamr-client/dist/types/src/utils/Signal';
 import {
 	MessageID,
@@ -23,6 +23,7 @@ import { Transform, TransformCallback } from 'stream';
 
 import { CONFIG_TEST } from '../../src/ConfigTest';
 import { LogStoreClient } from '../../src/LogStoreClient';
+import { LogStoreMessage } from '../../src/LogStoreMessageStream';
 import { createTestStream } from '../test-utils/utils';
 
 const originalFetch = fetch.default;
@@ -305,7 +306,7 @@ describe('query', () => {
 					});
 				});
 
-				const messages: Message[] = [];
+				const messages: LogStoreMessage[] = [];
 
 				const messagesQuery = await consumerClient.query(
 					{

--- a/packages/client/test/e2e/query.test.ts
+++ b/packages/client/test/e2e/query.test.ts
@@ -318,9 +318,9 @@ describe('query', () => {
 
 				// for some reason we can't just surround everything and catch errors
 				// there are some data pipelines that make it hard
-				// @ts-ignore
-				const signal: ErrorSignal = messagesQuery.onError;
-				// @ts-ignore
+				// @ts-expect-error this is marked as @internal
+				const signal: ErrorSignal = messagesQuery.messageStream.onError;
+				// @ts-expect-error mocking
 				signal.listeners = [errorListener];
 
 				// using this form to ensure that the iterator is done before the test ends


### PR DESCRIPTION
created experimental?.enableValidator feature flag at logstore plugin config

disables ReportPoller start

disables SystemRecovery start

disables SystemCache start

disables recovery endpoint

by default root build now ignores validator package. So we don't get errors from future changes added build:experimental as the previous behavior