### PR TITLE
Add conversion output rounding and minting test

### DIFF
--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -95,6 +95,36 @@ describe('direct cli call tests', function () {
 	);
 
 	test(
+		'mint with usd',
+		async ({ credentialsString, logstoreClient }) => {
+			const MINT_AMOUNT_USD = '0.001';
+			const mintResult = await logstoreClient.convert({
+				amount: MINT_AMOUNT_USD,
+				from: 'usd',
+				to: 'bytes',
+			});
+
+			const balance = await logstoreClient.getBalance();
+
+			const expectedBalance = balance + BigInt(mintResult);
+
+			const { code, stdout, stderr } = await executeOnCli(
+				`mint -u ${MINT_AMOUNT_USD} ${credentialsString} `
+			);
+
+			expect(code).toBe(0);
+			expect(stderr).toBe('');
+			expect(stdout).toContain('Successfully minted tokens to network:Tx');
+			expect(stdout).toContain('Amount:Tx ');
+
+			const newBalance = await logstoreClient.getBalance();
+
+			expect(newBalance).toBe(BigInt(expectedBalance));
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
 		'query stake',
 		async ({ logstoreClient, credentialsString }) => {
 			const previousQueryBalance = await logstoreClient.getQueryBalance();

--- a/packages/client/src/registry/TokenManager.ts
+++ b/packages/client/src/registry/TokenManager.ts
@@ -161,9 +161,17 @@ export class TokenManager {
 			}
 		};
 
+		const outputDecimals = {
+			wei: 0,
+			usd: 6,
+			bytes: 0,
+		};
+
 		const result = new Decimal(amount.toString())
 			.mul(await getInputConversion())
-			.div(await getOutputConversion());
+			.div(await getOutputConversion())
+			.toDP(outputDecimals[to], Decimal.ROUND_DOWN);
+
 		return result.toString();
 	}
 }

--- a/packages/client/test/e2e/token-manager.test.ts
+++ b/packages/client/test/e2e/token-manager.test.ts
@@ -117,7 +117,7 @@ describe('Manage tokens', () => {
 			});
 
 			expect(ethers.utils.formatEther(bytesToWei)).toMatchInlineSnapshot(
-				`"0.999999999909759537"`
+				`"0.99999999864981264"`
 			);
 
 			// $0.709104 at 28/07/2023. We will assume that pricing will be between 0.3 and 1.5 USD
@@ -126,4 +126,22 @@ describe('Manage tokens', () => {
 		},
 		TIMEOUT
 	);
+
+	test('result from conversion to wei should be an integer', async () => {
+		const inUsd = '0.001';
+
+		logger.debug(`Converting ${inUsd} usd to wei`);
+
+		const usdToWei = await accountClient.convert({
+			from: 'usd',
+			to: 'wei',
+			amount: inUsd.toString(),
+		});
+
+		const result = new Decimal(usdToWei);
+		const decimals = result.mod(1).toString();
+
+		expect(decimals).toBe('0');
+		expect(result.gte(0)).toBe(true);
+	});
 });


### PR DESCRIPTION
The TokenManager conversion method now includes rounding output to their respective decimals variable. This prevents decimals from appearing in conversions that should result in integers. Additionally, a test for the 'mint with usd' command has been added to the commands test suite. Another test was added to ensure the result of a conversion to wei is an integer.