### PR TITLE
Fix `Unexpected end of JSON input` issue

### DIFF
--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -130,6 +130,9 @@ export class HttpUtil {
 
 			stream = source.pipe(
 				split2((message: string) => {
+					if (!message) {
+						return;
+					}
 					const msgObject = JSON.parse(message);
 					if (Array.isArray(msgObject)) {
 						return StreamMessage.deserialize(msgObject);


### PR DESCRIPTION
Fix `Unexpected end of JSON input` issue, caused by an attempt to parse an empty string